### PR TITLE
toolbar flexbox gap workaround for safari

### DIFF
--- a/client/src/components/ReviewCardListConnected/components/FilterButtonTray/FilterButtonTray.styles.ts
+++ b/client/src/components/ReviewCardListConnected/components/FilterButtonTray/FilterButtonTray.styles.ts
@@ -4,8 +4,10 @@ export const useStyles = makeStyles((theme) => ({
   container: {
     display: 'flex',
     flexDirection: 'row',
-    gap: theme.spacing(1),
     justifyContent: 'flex-end',
     padding: theme.spacing(1),
+    '& > * + *': {
+      marginLeft: theme.spacing(1),
+    },
   },
 }));

--- a/client/src/components/ReviewCardListConnected/components/Toolbar/Toolbar.styles.ts
+++ b/client/src/components/ReviewCardListConnected/components/Toolbar/Toolbar.styles.ts
@@ -5,13 +5,18 @@ export const useStyles = makeStyles((theme) => ({
     display: 'flex',
     [theme.breakpoints.down('xs')]: {
       flexDirection: 'column',
+      '& > * + *': {
+        marginBottom: theme.spacing(1),
+      },
     },
     [theme.breakpoints.up('sm')]: {
       flexDirection: 'row',
+      '& > * + *': {
+        marginLeft: theme.spacing(1),
+      },
     },
     alignItems: 'flex-end',
     justifyContent: 'flex-end',
-    gap: theme.spacing(1),
   },
   ml: {
     marginLeft: theme.spacing(1),


### PR DESCRIPTION
As `gap` isn't supported for `flexbox` by Safari, I got rid of it for the toolbar and implemented a workaround. 